### PR TITLE
chore: disable utl api

### DIFF
--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -10,8 +10,6 @@ import React from 'react';
 import { useState } from 'react';
 import useAsyncEffect from 'use-async-effect';
 
-import { getTokenInfoWithoutOnChainFallback } from '@/app/utils/token-info';
-
 import { Copyable } from './Copyable';
 
 type Props = {
@@ -113,30 +111,4 @@ const useTokenMetadata = (useMetadata: boolean | undefined, pubkey: string) => {
         [useMetadata, pubkey, url, data, setData]
     );
     return { data };
-};
-
-const useTokenInfo = (fetchTokenLabelInfo: boolean | undefined, pubkey: string) => {
-    const [info, setInfo] = useState<TokenLabelInfo>();
-    const { cluster, url } = useCluster();
-
-    useAsyncEffect(
-        async isMounted => {
-            if (!fetchTokenLabelInfo) return;
-            if (!info) {
-                try {
-                    const token = await getTokenInfoWithoutOnChainFallback(new PublicKey(pubkey), cluster);
-                    if (isMounted()) {
-                        setInfo(token);
-                    }
-                } catch {
-                    if (isMounted()) {
-                        setInfo(undefined);
-                    }
-                }
-            }
-        },
-        [fetchTokenLabelInfo, pubkey, cluster, url, info, setInfo]
-    );
-
-    return info;
 };

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -57,11 +57,6 @@ export function Address({
         addressLabel = metaplexData.data.data.name;
     }
 
-    const tokenInfo = useTokenInfo(fetchTokenLabelInfo, address);
-    if (tokenInfo) {
-        addressLabel = displayAddress(address, cluster, tokenInfo);
-    }
-
     if (truncateChars && addressLabel === address) {
         addressLabel = addressLabel.slice(0, truncateChars) + '…';
     }

--- a/app/utils/token-info.ts
+++ b/app/utils/token-info.ts
@@ -110,9 +110,9 @@ export async function getFullTokenInfo(
     if (!sdkTokenInfo) {
         return legacyCdnTokenInfo
             ? {
-                ...legacyCdnTokenInfo,
-                verified: true,
-            }
+                  ...legacyCdnTokenInfo,
+                  verified: true,
+              }
             : undefined;
     }
 

--- a/app/utils/token-info.ts
+++ b/app/utils/token-info.ts
@@ -1,6 +1,5 @@
 import { Connection, PublicKey } from '@solana/web3.js';
 import { ChainId, Client, Token, UtlConfig } from '@solflare-wallet/utl-sdk';
-
 import { Cluster } from './cluster';
 
 type TokenExtensions = {
@@ -69,38 +68,8 @@ export async function getTokenInfo(
 ): Promise<Token | undefined> {
     const client = makeUtlClient(cluster, connectionString);
     if (!client) return undefined;
-    const token = await client.fetchMint(address);
+    const [token] = await client.getFromMetaplex([address]);
     return token;
-}
-
-type UtlApiResponse = {
-    content: Token[]
-}
-
-export async function getTokenInfoWithoutOnChainFallback(
-    address: PublicKey,
-    cluster: Cluster
-): Promise<Token | undefined> {
-    const chainId = getChainId(cluster);
-    if (!chainId) return undefined;
-
-    // Request token info directly from UTL API
-    // We don't use the SDK here because we don't want it to fallback to an on-chain request
-    const response = await fetch(`https://token-list-api.solana.cloud/v1/mints?chainId=${chainId}`, {
-        body: JSON.stringify({ addresses: [address.toBase58()] }),
-        headers: {
-            "Content-Type": "application/json",
-        },
-        method: 'POST',
-    });
-
-    if (response.status >= 400) {
-        console.error(`Error calling UTL API for address ${address} on chain ID ${chainId}. Status ${response.status}`);
-        return undefined;
-    }
-
-    const fetchedData = await response.json() as UtlApiResponse;
-    return fetchedData.content[0];
 }
 
 async function getFullLegacyTokenInfoUsingCdn(


### PR DESCRIPTION
The explorer uses Solflare's UTL API to load token metadatas and only fallbacks to Metaplex metadata if the query to that on-chain API fails.

Since this API is not relevant to Fogo, I want to disable the code paths that query it so we instead get the Metaplex metadata in the explorer.